### PR TITLE
Fix missing package dependencies in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ classifiers =
 packages =
     fastq
 python_requires = >=3.7
+setup_requires =
+    miniFasta >=3.0.1
 package_dir =
     =src
 zip_safe = no


### PR DESCRIPTION
Hi Jules,

Thanks for this package, I share your interest for a standalone FASTQ reader without too much dependencies (I have [`gb-io.py`](https://github.com/althonos/gb-io.py) for GenBank files for the same purpose).

At the moment, installing `fastq` with `pip` does not install `miniFasta` automatically because it's not declared in `setup.cfg`. This PR fixes that. Other option would be to make `miniFasta` optional by making the `toFasta` raise an error on `miniFasta` import failure.